### PR TITLE
GitHubDeleteIssueById

### DIFF
--- a/src/examples/GitHubDeleteIssueById.md
+++ b/src/examples/GitHubDeleteIssueById.md
@@ -1,0 +1,32 @@
+
+---
+description: |
+  You'll need to find the GitHub issue id first (see the [GitHubFindIssueIdByNumber](GitHubFindIssueIdByNumber) example) to use as the argument to `issueId`.
+
+Since issue ids are globally unique across every kind of object in GitHub, you won't need to add the repository owner/name, just the `id`!
+
+  ```javascript
+  {
+    "id": "MDU6SXNzdWU1NDUyNDk2ODg="
+  }
+  ```
+contributedBy: @sgrove
+---
+
+```graphql
+mutation DeleteIssueById($id: ID!) {
+  gitHub {
+    deleteIssue(input: { issueId: $id }) {
+      repository {
+        issues(
+          first: 0
+          orderBy: { direction: DESC, field: CREATED_AT }
+        ) {
+          totalCount
+        }
+      }
+    }
+  }
+}
+
+```

--- a/src/examples/GitHubDeleteIssueById.md
+++ b/src/examples/GitHubDeleteIssueById.md
@@ -1,16 +1,15 @@
-
 ---
 description: |
   You'll need to find the GitHub issue id first (see the [GitHubFindIssueIdByNumber](GitHubFindIssueIdByNumber) example) to use as the argument to `issueId`.
-
-Since issue ids are globally unique across every kind of object in GitHub, you won't need to add the repository owner/name, just the `id`!
-
+  
+  Since issue ids are globally unique across every kind of object in GitHub, you won't need to add the repository owner/name, just the `id`!
+  
   ```javascript
   {
     "id": "MDU6SXNzdWU1NDUyNDk2ODg="
   }
   ```
-contributedBy: @sgrove
+contributedBy: "@sgrove"
 ---
 
 ```graphql


### PR DESCRIPTION
You'll need to find the GitHub issue id first (see the [GitHubFindIssueIdByNumber](GitHubFindIssueIdByNumber) example) to use as the argument to `issueId`.

Since issue ids are globally unique across every kind of object in GitHub, you won't need to add the repository owner/name, just the `id`!

  ```javascript
  {
    "id": "MDU6SXNzdWU1NDUyNDk2ODg="
  }
  ```